### PR TITLE
[Refactor]: 혈당그래프 하단 리스트 표시

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/navigation/NavGraph.kt
@@ -189,7 +189,7 @@ fun NavGraph(
             //홈 상세 화면_혈당 화면
 
             composable(route = Route.GlucoseDetail.route) {
-                GlucoseDetail(navController = navController, calendarViewModel = calendarViewModel)
+                GlucoseDetail(navController = navController)
             }
 
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/home/HomeViewModel.kt
@@ -94,7 +94,10 @@ class HomeViewModel @Inject constructor(
             }
         }
     }
-
+    // 케어콜 후 데이터 불러오기
+    fun forceRefreshHomeData() {
+        _selectedElderId.value = _selectedElderId.value
+    }
     // 서버에서 어르신 전체 목록을 불러옴
     private fun fetchElderList() {
         viewModelScope.launch {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/home/screen/HomeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.konkuk.medicarecall.R
@@ -64,6 +68,7 @@ import com.konkuk.medicarecall.ui.home.model.HomeUiState
 import com.konkuk.medicarecall.ui.home.model.MedicineUiState
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.main
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -85,8 +90,14 @@ fun HomeScreen(
 
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-
+    // 데이터 갱신
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            homeViewModel.forceRefreshHomeData()
+        }
+    }
 
     HomeScreenLayout(
         modifier = modifier,
@@ -111,6 +122,8 @@ fun HomeScreen(
         onFabClick = {
             scope.launch {
                 snackbarHostState.showSnackbar("케어콜이 곧 연결됩니다. 잠시만 기다려 주세요.")
+                delay(3000) // 케어콜 데이터 처리 기다리는 시간
+                homeViewModel.forceRefreshHomeData()
             }
         }
     )
@@ -155,7 +168,10 @@ fun HomeScreenLayout(
         },
         floatingActionButtonPosition = FabPosition.Center,
     ) { innerPadding ->
-        Box(modifier = modifier.fillMaxSize()) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+        ) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
@@ -200,9 +216,9 @@ fun HomeScreenLayout(
                             ) {
 
 
-                                //val balloonText = "아침·점심 복약과 식사는 문제 없으나, 저녁 약 복용이 늦어질 우려가 있어요."
+
                                 val balloonText = homeUiState.balloonMessage
-                                val trimmedText = balloonText.take(45) // 글자 수 제한
+                                val trimmedText = balloonText.take(45)
 
 
                                 //말풍선

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/GlucoseViewModel.kt
@@ -1,9 +1,7 @@
 package com.konkuk.medicarecall.ui.homedetail.glucoselevel
 
 import android.util.Log
-import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.ui.homedetail.glucoselevel.data.GlucoseRepository
@@ -13,6 +11,8 @@ import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GraphDataPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
@@ -23,12 +23,12 @@ class GlucoseViewModel @Inject constructor(
 ) : ViewModel() {
 
     private companion object {
-        const val TAG = "GLUCOSE_API"
+        const val TAG = "GLUCOSE_VM"
     }
 
     // UI State
     private val _uiState = MutableStateFlow(GlucoseUiState())
-    val uiState: StateFlow<GlucoseUiState> = _uiState
+    val uiState: StateFlow<GlucoseUiState> = _uiState.asStateFlow()
 
     // 내부 캐시
     private var beforeMealData = mutableStateListOf<GraphDataPoint>()
@@ -37,46 +37,62 @@ class GlucoseViewModel @Inject constructor(
     fun getGlucoseData(
         elderId: Int,
         counter: Int,
-        type: GlucoseTiming
+        type: GlucoseTiming,
+        isRefresh: Boolean = false
     ) {
-        _uiState.value = _uiState.value.copy(isLoading = true)
+        _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             glucoseRepository.getGlucoseGraph(elderId, counter, type.toString())
-                .onSuccess {
-                    when (type) {
+                .onSuccess { response ->
+                    val processedData = response.data
+                        .distinctBy { it.date }
+                        .reversed()
+
+                    val newData = processedData.map { record ->
+                        GraphDataPoint(
+                            date = LocalDate.parse(record.date),
+                            value = record.value.toFloat()
+                        )
+                    }
+
+                    val updatedDataList = when (type) {
                         GlucoseTiming.BEFORE_MEAL -> {
-                            beforeMealData.addAll(0, it.data.reversed().map { record ->
-                                GraphDataPoint(
-                                    date = LocalDate.parse(record.date),
-                                    value = record.value.toFloat()
-                                )
-                            })
-                            _uiState.value = _uiState.value.copy(
-                                graphDataPoints = beforeMealData,
-                                selectedIndex = beforeMealData.lastIndex
-                            )
+                            if (isRefresh) beforeMealData.clear()
+                            beforeMealData.addAll(0, newData)
+                            beforeMealData
                         }
-
                         GlucoseTiming.AFTER_MEAL -> {
-                            afterMealData.addAll(0, it.data.reversed().map { record ->
-                                GraphDataPoint(
-                                    date = LocalDate.parse(record.date),
-                                    value = record.value.toFloat()
-                                )
-                            })
-                            _uiState.value = _uiState.value.copy(
-                                graphDataPoints = afterMealData,
-                                selectedIndex = afterMealData.lastIndex
-                            )
-
+                            if (isRefresh) afterMealData.clear()
+                            afterMealData.addAll(0, newData)
+                            afterMealData
                         }
                     }
 
-                    _uiState.value = _uiState.value.copy(hasNext = it.hasNextPage)
+                    // 현재 선택된 타이밍과 일치하는 경우에만 UI를 업데이트
+                    if (_uiState.value.selectedTiming == type) {
+                        _uiState.update {
+
+                            // 새로고침일 때만 선택 인덱스를 업데이트
+                            val newSelectedIndex = if (isRefresh) {
+                                // 가장 최근 날짜(마지막 인덱스)를 선택
+                                updatedDataList.lastIndex.takeIf { i -> i >= 0 } ?: -1
+                            } else {
+                                it.selectedIndex // 새로고침이 아니면 기존 선택 유지
+                            }
+
+
+                            it.copy(
+                                graphDataPoints = updatedDataList,
+                                selectedIndex = newSelectedIndex,
+                                hasNext = response.hasNextPage
+                            )
+                        }
+                    }
                 }
-            _uiState.value = _uiState.value.copy(isLoading = false)
-
-
+                .onFailure { error ->
+                    Log.e(TAG, "getGlucoseData failed", error)
+                }
+            _uiState.update { it.copy(isLoading = false) }
         }
     }
 
@@ -86,16 +102,18 @@ class GlucoseViewModel @Inject constructor(
         Log.d(TAG, "updateTiming(newTiming=$newTiming)")
         val dataToShow =
             if (newTiming == GlucoseTiming.BEFORE_MEAL) beforeMealData else afterMealData
-        _uiState.value = _uiState.value.copy(
-            graphDataPoints = dataToShow,
-            selectedTiming = newTiming,
-            hasNext = true,
-            selectedIndex = dataToShow.lastIndex,
-        )
+        _uiState.update {
+            it.copy(
+                graphDataPoints = dataToShow,
+                selectedTiming = newTiming,
+                hasNext = true, // 타이밍 전환 시에는 항상 다음 페이지가 있다고 가정
+                selectedIndex = dataToShow.lastIndex.takeIf { i -> i >= 0 } ?: -1,
+            )
+        }
     }
 
 
     fun onClickDots(newIndex: Int) {
-        _uiState.value.copy(selectedIndex = newIndex)
+        _uiState.value = _uiState.value.copy(selectedIndex = newIndex)
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/GlucoseViewModel.kt
@@ -44,9 +44,7 @@ class GlucoseViewModel @Inject constructor(
         viewModelScope.launch {
             glucoseRepository.getGlucoseGraph(elderId, counter, type.toString())
                 .onSuccess { response ->
-                    val processedData = response.data
-                        .distinctBy { it.date }
-                        .reversed()
+                    val processedData = response.data.reversed()
 
                     val newData = processedData.map { record ->
                         GraphDataPoint(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/component/GlucoseGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/component/GlucoseGraph.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -27,7 +26,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GlucoseLevel
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GlucoseTiming
 import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GraphDataPoint
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.classifyGlucose
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -39,6 +41,7 @@ fun GlucoseGraph(
     scrollState: ScrollState,
     selectedIndex: Int,
     onPointClick: (Int) -> Unit,
+    timing: GlucoseTiming,
 ) {
     val colors = MediCareCallTheme.colors
     val lineColor = colors.gray2
@@ -124,10 +127,10 @@ fun GlucoseGraph(
                         //점
                         points.forEachIndexed { index, point ->
                             val value = data[index].value
-                            val color = when {
-                                value < 90f -> colors.active
-                                value < 130f -> colors.main
-                                else -> colors.negative
+                            val color = when (classifyGlucose(value, timing)) {   // 공복/식후 기준 반영
+                                GlucoseLevel.LOW    -> colors.active     // 낮음
+                                GlucoseLevel.NORMAL -> colors.main       // 정상
+                                GlucoseLevel.HIGH   -> colors.negative   // 높음
                             }
                             if (index == selectedIndex) {
                                 drawCircle(color = color.copy(alpha = 0.2f), radius = iconRadiusDp.toPx() * 3, center = point)
@@ -193,7 +196,8 @@ fun PreviewGlucoseGraph_TwoPoints() {
             data = sampleData,
             selectedIndex = sampleData.lastIndex,
             onPointClick = {},
-            scrollState = scrollState
+            scrollState = scrollState,
+            timing = GlucoseTiming.BEFORE_MEAL
         )
     }
 }
@@ -214,7 +218,8 @@ fun PreviewGlucoseGraph_ManyPoints() {
             data = sampleData,
             selectedIndex = sampleData.lastIndex,
             onPointClick = {},
-            scrollState = scrollState
+            scrollState = scrollState,
+            timing = GlucoseTiming.AFTER_MEAL
         )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/component/GlucoseListItem.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/component/GlucoseListItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GlucoseTiming
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -23,7 +24,8 @@ fun GlucoseListItem(
     modifier: Modifier = Modifier,
     date: LocalDate,
     timingLabel: String,
-    value: Int
+    value: Int,
+    timing: GlucoseTiming
 ) {
     val formatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
     val formattedDate = date.format(formatter)
@@ -66,7 +68,10 @@ fun GlucoseListItem(
 
             Spacer(Modifier.weight(1f))
 
-            GlucoseStatusChip(value)//낮음,정상,높음
+            GlucoseStatusChip(
+                value = value,
+                timing = timing
+            )//낮음,정상,높음
 
 
         }
@@ -81,7 +86,8 @@ private fun PreviewGlucoseListItem() {
         GlucoseListItem(
             date = LocalDate.now(),
             timingLabel = "아침 | 공복",
-            value = 180
+            value = 180,
+            timing = GlucoseTiming.BEFORE_MEAL
         )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/component/GlucoseStatusChip.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/component/GlucoseStatusChip.kt
@@ -14,22 +14,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GlucoseLevel
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.GlucoseTiming
+import com.konkuk.medicarecall.ui.homedetail.glucoselevel.model.classifyGlucose
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 
 @Composable
 fun GlucoseStatusChip(
-    value: Int
+    value: Int,
+    timing: GlucoseTiming
 ) {
-    val statusText = when {
-        value >= 130 -> "높음"
-        value <= 90 -> "낮음"
-        else -> "정상"
-    }
-
-    val statusColor = when (statusText) {
-        "높음" -> MediCareCallTheme.colors.negative
-        "낮음" -> MediCareCallTheme.colors.active
-        else -> MediCareCallTheme.colors.positive
+    val level = classifyGlucose(value.toFloat(), timing)
+    val (text, color) = when (level) {
+        GlucoseLevel.LOW    -> "낮음" to MediCareCallTheme.colors.active
+        GlucoseLevel.NORMAL -> "정상" to MediCareCallTheme.colors.main
+        GlucoseLevel.HIGH   -> "높음" to MediCareCallTheme.colors.negative
     }
 
 
@@ -37,8 +36,7 @@ fun GlucoseStatusChip(
         modifier = Modifier
             .height(30.dp),
         shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(containerColor = statusColor),
-
+        colors = CardDefaults.cardColors(containerColor = color)
         ) {
         Row(
             modifier = Modifier
@@ -48,7 +46,7 @@ fun GlucoseStatusChip(
 
             ) {
             Text(
-                text = statusText,
+                text = text,
                 style = MediCareCallTheme.typography.R_16,
                 color = Color.White
             )
@@ -58,6 +56,12 @@ fun GlucoseStatusChip(
 
 @Preview
 @Composable
-private fun PreviewGlucoseStatusChip() {
-    GlucoseStatusChip(value = 100)
+private fun PreviewGlucoseStatusChip_Before() {
+    GlucoseStatusChip(value = 89, timing = GlucoseTiming.BEFORE_MEAL)
+}
+
+@Preview
+@Composable
+private fun PreviewGlucoseStatusChip_After() {
+    GlucoseStatusChip(value = 150, timing = GlucoseTiming.AFTER_MEAL)
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/model/GlucoseClassifier.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/model/GlucoseClassifier.kt
@@ -1,0 +1,24 @@
+package com.konkuk.medicarecall.ui.homedetail.glucoselevel.model
+
+
+
+enum class GlucoseLevel { LOW, NORMAL, HIGH }
+
+private data class Range(val lowUpper: Float, val normalUpper: Float)
+
+// 65세 이상 건강노인 기준 혈당 상태 구분
+private fun rangeFor(timing: GlucoseTiming): Range = when (timing) {
+    GlucoseTiming.BEFORE_MEAL -> Range(lowUpper = 90f, normalUpper = 130f) // 식전: <90 / 90~130 / >130
+    GlucoseTiming.AFTER_MEAL  -> Range(lowUpper = 90f, normalUpper = 150f) // 식후: <90 / 90~150 / >150
+}
+
+/** x: mg/dL 값 */
+fun classifyGlucose(x: Float, timing: GlucoseTiming): GlucoseLevel {
+    val r = rangeFor(timing)
+    return when {
+        x < r.lowUpper     -> GlucoseLevel.LOW
+        x <= r.normalUpper -> GlucoseLevel.NORMAL   // 경계 포함
+        else               -> GlucoseLevel.HIGH
+    }
+}
+

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/screen/GlucoseDetail.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/screen/GlucoseDetail.kt
@@ -216,7 +216,8 @@ fun GlucoseDetailLayout(
                     data = uiState.graphDataPoints,
                     selectedIndex = selectedIndex,
                     onPointClick = onPointClick,
-                    scrollState = scrollState
+                    scrollState = scrollState,
+                    timing = selectedTiming
                 )
                 Spacer(modifier = Modifier.height(24.dp))
 
@@ -234,7 +235,8 @@ fun GlucoseDetailLayout(
                     GlucoseListItem(
                         date = selectedPoint.date,
                         timingLabel = timingLabel,
-                        value = selectedPoint.value.toInt()
+                        value = selectedPoint.value.toInt(),
+                        timing = selectedTiming
                     )
                 }
             }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/screen/GlucoseDetail.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/glucoselevel/screen/GlucoseDetail.kt
@@ -23,12 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,10 +33,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.konkuk.medicarecall.R
-import com.konkuk.medicarecall.ui.calendar.CalendarViewModel
 import com.konkuk.medicarecall.ui.home.HomeViewModel
 import com.konkuk.medicarecall.ui.homedetail.TopAppBar
 import com.konkuk.medicarecall.ui.homedetail.glucoselevel.GlucoseViewModel
@@ -55,16 +53,12 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import kotlin.collections.getValue
-import kotlin.collections.setValue
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun GlucoseDetail(
     modifier: Modifier = Modifier,
-    navController: NavHostController,
-    viewModel: GlucoseViewModel = hiltViewModel(),
-    calendarViewModel: CalendarViewModel
+    navController: NavHostController
 ) {
 
     val scrollState = rememberScrollState()
@@ -74,13 +68,14 @@ fun GlucoseDetail(
         navController.getBackStackEntry("main")
     }
     val homeViewModel: HomeViewModel = hiltViewModel(homeEntry)
+    val viewModel: GlucoseViewModel = hiltViewModel(homeEntry)
 
     val uiState by viewModel.uiState.collectAsState()
 
     // 선택된 어르신 ID를 구독 (null 가능)
-    val elderId = homeViewModel.selectedElderId.collectAsState().value
+    val elderId by homeViewModel.selectedElderId.collectAsState()
 
-    var counter = remember {
+    val counter = remember {
         mutableStateMapOf(
             GlucoseTiming.BEFORE_MEAL to 0, GlucoseTiming.AFTER_MEAL to 0
         )
@@ -88,39 +83,43 @@ fun GlucoseDetail(
 
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(counter[GlucoseTiming.BEFORE_MEAL], counter[GlucoseTiming.AFTER_MEAL]) {
-        Log.d("glucose_counter", "$counter")
-
-    }
-
-
-    LaunchedEffect(Unit) {
-        elderId?.let { id ->
-
-            viewModel.getGlucoseData(elderId = id, counter.getValue(uiState.selectedTiming),
-                GlucoseTiming.AFTER_MEAL)
-            viewModel.getGlucoseData(elderId = id, counter.getValue(uiState.selectedTiming),
-                GlucoseTiming.BEFORE_MEAL)
-            counter[GlucoseTiming.BEFORE_MEAL] = counter[GlucoseTiming.BEFORE_MEAL]!! + 1
-            counter[GlucoseTiming.AFTER_MEAL] = counter[GlucoseTiming.AFTER_MEAL]!! + 1
-
-
+    // 데이터 새로고침 로직
+    val refreshData = remember(viewModel) {
+        {
+            elderId?.let { id ->
+                counter[GlucoseTiming.BEFORE_MEAL] = 0
+                counter[GlucoseTiming.AFTER_MEAL] = 0
+                viewModel.getGlucoseData(id, 0, GlucoseTiming.BEFORE_MEAL, true)
+                viewModel.getGlucoseData(id, 0, GlucoseTiming.AFTER_MEAL, true)
+            }
         }
     }
+
+    // 어르신이 바뀔 때마다 데이터를 새로고침합니다.
+    LaunchedEffect(elderId) {
+        refreshData()
+    }
+
+    // 화면에 다시 진입할 때마다 데이터를 새로고침합니다.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        refreshData()
+    }
+
+
+    // 무한 스크롤
     LaunchedEffect(scrollState.value) {
         Log.d("scroll", "${scrollState.value}")
         if (scrollState.value > scrollState.maxValue - 250 && elderId != null && !uiState.isLoading && uiState.hasNext) {
-            viewModel.getGlucoseData(elderId, counter.getValue(uiState.selectedTiming), uiState.selectedTiming)
-            counter[uiState.selectedTiming] = counter[uiState.selectedTiming]!! + 1
+            val currentTiming = uiState.selectedTiming
+            val currentPage = counter.getValue(currentTiming)
+            viewModel.getGlucoseData(elderId!!, currentPage + 1, currentTiming)
+            counter[currentTiming] = currentPage + 1
         }
     }
-
-
 
     GlucoseDetailLayout(
         modifier = modifier,
         uiState = uiState,
-
         selectedTiming = uiState.selectedTiming,
         selectedIndex = uiState.selectedIndex,
 
@@ -270,7 +269,7 @@ fun GlucoseDetailLayout(
 @Preview(showBackground = true, name = "데이터 있을 때")
 @Composable
 fun PreviewGlucoseDetail_DataAvailable() {
-    // 프리뷰 용 더미 데이터
+    // 더미 데이터 프리뷰
     val today = LocalDate.now()
     val sampleData = (0..6).map { i ->
         GraphDataPoint(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/sleep/component/SleepDetailCard.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/sleep/component/SleepDetailCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.ui.homedetail.sleep.model.SleepUiState
@@ -26,11 +25,9 @@ import com.konkuk.medicarecall.ui.theme.figmaShadow
 
 @Composable
 fun SleepDetailCard(
-
     sleeps: SleepUiState,
     modifier: Modifier = Modifier
 ) {
-
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -38,10 +35,8 @@ fun SleepDetailCard(
                 group = LocalMediCareCallShadowProvider.current.shadow03,
                 cornerRadius = 14.dp
             ),
-
         colors = CardDefaults.cardColors(containerColor = Color.White),
         shape = RoundedCornerShape(10.dp)
-
     ) {
         Column(
             modifier = Modifier
@@ -49,22 +44,17 @@ fun SleepDetailCard(
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(11.dp)
         ) {
-
-
             //1) 총 수면 시간
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
+                modifier = Modifier.fillMaxWidth()
             ) {
                 Column {
-
                     Text(
                         text = "총 수면시간",
                         style = MediCareCallTheme.typography.R_15,
                         color = MediCareCallTheme.colors.gray5
                     )
                     Spacer(modifier = Modifier.height(4.dp))
-
                     Row(
                         modifier = Modifier,
                         verticalAlignment = Alignment.Bottom
@@ -81,51 +71,39 @@ fun SleepDetailCard(
                             color = MediCareCallTheme.colors.gray8,
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-
                         Text(
                             text = if (sleeps.isRecorded) "${sleeps.totalSleepMinutes}" else "--",
                             style = MediCareCallTheme.typography.SB_22,
                             color = MediCareCallTheme.colors.gray8,
                         )
-
                         Spacer(modifier = Modifier.width(4.dp))
-
                         Text(
                             "분",
                             style = MediCareCallTheme.typography.R_16,
                             color = MediCareCallTheme.colors.gray8,
                         )
-
-
                     }
                 }
-
             }
-
-
 
             //취침 + 기상
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) { // TODO: 오전 오후 수정
+                modifier = Modifier.fillMaxWidth()
+            ) {
                 //2) 취침 시간
                 Column {
-
                     Text(
                         text = "취침 시간",
                         style = MediCareCallTheme.typography.R_15,
                         color = MediCareCallTheme.colors.gray5
                     )
                     Spacer(modifier = Modifier.height(4.dp))
-
                     Row(
                         modifier = Modifier,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-
                         Text(
-                            text = sleeps.bedTime,
+                            text = sleeps.bedTime.ifBlank { "오후 --:--" },
                             style = MediCareCallTheme.typography.SB_16,
                             color = MediCareCallTheme.colors.gray8,
                         )
@@ -135,40 +113,33 @@ fun SleepDetailCard(
                 Spacer(modifier = Modifier.width(32.dp))
 
                 //3) 기상 시간
-
                 Column {
-
                     Text(
                         text = "기상 시간",
                         style = MediCareCallTheme.typography.R_15,
                         color = MediCareCallTheme.colors.gray5
                     )
                     Spacer(modifier = Modifier.height(4.dp))
-
                     Row(
                         modifier = Modifier,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = sleeps.wakeUpTime,
+                            text = sleeps.wakeUpTime.ifBlank { "오전 --:--" },
                             style = MediCareCallTheme.typography.SB_16,
                             color = MediCareCallTheme.colors.gray8,
                         )
-
-
                     }
                 }
-
             }
         }
-
     }
 }
 
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, name="기록 있음")
 @Composable
-fun PreviewSleepDetailCard() {
+fun PreviewSleepDetailCard_Recorded() {
     SleepDetailCard(
         sleeps = SleepUiState(
             date = "2025-07-07",
@@ -179,6 +150,12 @@ fun PreviewSleepDetailCard() {
             isRecorded = true
         )
     )
+}
 
-
+@Preview(showBackground = true, name="미기록")
+@Composable
+fun PreviewSleepDetailCard_Unrecorded() {
+    SleepDetailCard(
+        sleeps = SleepUiState.EMPTY
+    )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/sleep/model/SleepResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/homedetail/sleep/model/SleepResponseDto.kt
@@ -1,5 +1,8 @@
 package com.konkuk.medicarecall.ui.homedetail.sleep.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class SleepResponseDto(
     val date: String,
     val totalSleep: TotalSleepDto?,  // null이면 미기록으로 간주
@@ -7,6 +10,7 @@ data class SleepResponseDto(
     val wakeTime: String?            // 기상 시간 (예: "06:00")
 )
 
+@Serializable
 data class TotalSleepDto(
     val hours: Int?,
     val minutes: Int?


### PR DESCRIPTION
GlucoseDetailScreen
- 화면 진입/복귀시 가장 최근 혈당값이 찍힌 점이 선택, 하단에 리스트 표시
- 네임드롭 어르신 전환시 혈당 그래프 데이터 전환 
- 건강노인 공복/ 식후 혈당범위 적용

-65세 이상 건강노인 식전 혈당범위
낮음 :  x < 90
적절 :  90<=x <=130
높음 : x > 130 
-65세 이상 건강노인 식후 혈당범위
낮음 :  x < 90
적절 :  90<=x <=150
높음 : x > 150

GlucoseViewModel 
- 데이터 새로고침 로직 개선
- 같은 날짜 다른 혈당값 중복값 노출

HomeScreen
- LaunchedEffect를 적용하여 케어콜 완료후 홈화면 데이터 갱신

SleepDetailScreen
- 수면데이터 반영안되던것 수정
- 미기록 텍스트 적용
